### PR TITLE
Generalizes AMI creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 secrets/*
+!secrets/REDACTED-params.yaml
 !secrets/params.yaml
 !secrets/README.md
 work/*

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,6 @@
 creation_rules:
 - path: secrets/params.yaml
-  encrypted_regex: 'access_key|password'
+  encrypted_regex: 'access_key|password|api_token'
   pgp: 905EBD494A6AA2B774ED5C67621620CDA290611D
 #    ,ANOTHER_FALSE_KEY_HERE
 # You can also isolate each key to specific directories by uncommenting the next 7 lines and adding the appropriate fingerprints

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,68 @@
-pkrvars := ${SECRETS_DIR}/embedded-cluster.pkrvars.hcl
-params_yaml := ${SECRETS_DIR}/params.yaml
+PKRVARS_FILE := ${SECRETS_DIR}/embedded-cluster.pkrvars.hcl
+PARAMS := ${SECRETS_DIR}/params.yaml
+
+APPS := $(shell replicated app ls --output json | jq -c .) 
+APP_SLUGS := $(shell echo '$(APPS)' | jq -r '.[].app.slug')
 
 define PKRVARS
 project_root		 = "$(PROJECT_DIR)"
 
-application = "$(shell yq .application $(params_yaml))"
-admin_console_password = "$(shell sops --decrypt --extract '["admin_console_password"]' $(params_yaml))"
+instance_type = "$(shell yq .instance_type $(PARAMS))"
+volume_size = $(shell yq .volume_size $(PARAMS))
 
-instance_type = "$(shell yq .instance_type $(params_yaml))"
-volume_size = $(shell yq .volume_size $(params_yaml))
+source_ami = "$(shell yq .source_ami $(PARAMS))"
+access_key_id	= "$(shell sops --decrypt --extract '["aws"]["access_key_id"]' $(PARAMS))"
+secret_access_key	= "$(shell sops --decrypt --extract '["aws"]["secret_access_key"]' $(PARAMS))"
+regions = $(shell yq --output-format json .aws.regions $(PARAMS))
 
-source_ami = "$(shell yq .source_ami $(params_yaml))"
-access_key_id	= "$(shell sops --decrypt --extract '["aws"]["access_key_id"]' $(params_yaml))"
-secret_access_key	= "$(shell sops --decrypt --extract '["aws"]["secret_access_key"]' $(params_yaml))"
-region = "$(shell yq .aws.region $(params_yaml))"
+replicated_api_token="$(shell sops --decrypt --extract '["replicated"]["api_token"]' $(PARAMS))"
 endef
 
+define make-channel-targets
+.PHONY: image\:$(1)/$(2) ami\:$(1)/$(2) validate\:$(1)/$(2) debug\:$(1)/$(2) console\:$(1)/$(2)
+image\:$(1)/$(2): ami\:$(1)/$(2)
+
+ami\:$(1)/$(2): $(PKRVARS_FILE)
+	packer build --force --var 'application=$(1)' --var 'channel=$(2)' \
+		--var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
+
+validate\:$(1)/$(2): $(PKRVARS_FILE)
+	packer validate --var 'application=$(1)' --var 'channel=$(2)' \
+		--var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
+
+debug\:$(1)/$(2): $(PKRVARS_FILE)
+	packer build --force --debug --var 'application=$(1)' --var 'channel=$(2)' \
+		--var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
+
+console\:$(1)/$(2): $(PKRVARS_FILE)
+	packer console --var 'application=$(1)' --var 'channel=$(2)' \
+		--var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
+endef
+
+define make-app-targets
+CHANNELS := $(shell echo '$(APPS)' | jq -r --arg slug $(1) '.[] | select(.app.slug == $$slug) | .channels[].channelSlug')
+$(foreach element,$(CHANNELS),$(eval $(call make-channel-targets,$(1),$(element))))
+endef
+$(foreach element,$(APP_SLUGS),$(eval $(call make-app-targets,$(element))))
+
 .PHONY: pkrvars
-pkrvars: $(pkrvars)
+pkrvars: $(PKRVARS_FILE)
 
 export PKRVARS
-$(pkrvars): $(params_yaml)
+$(PKRVARS_FILE): $(PARAMS)
 	@echo "$$PKRVARS" > $@
 
 .PHONY: init
-init: $(pkrvars)
+init: $(PKRVARS_FILE)
 	packer init ${SOURCE_DIR}/packer
 
-.PHONY: create
-create: image
-
-.PHONY: image
-validate: $(pkrvars)
-	packer validate --var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
-
-.PHONY: image
-image: $(pkrvars)
-	packer build --force --var-file=${SECRETS_DIR}/embedded-cluster.pkrvars.hcl ${SOURCE_DIR}/packer
-
 clean:
-	@rm $(pkrvars)
+	@rm $(PKRVARS_FILE)
 
 .PHONY: encrypt
 encrypt: 
-	@sops --encrypt --in-place $(params_yaml)
+	@sops --encrypt --in-place $(PARAMS)
 
 .PHONY: decrypt
 decrypt: 
-	@sops --decrypt --in-place $(params_yaml)
+	@sops --decrypt --in-place $(PARAMS)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Replicated Embedded Cluster AMI
+
+## TL;DR
+
+1. Copy `secrets/REDACTED-params.yaml` to `secrets/params.yaml` and update for
+   your AWS account.
+2. Log in with the Replicated CLI 
+3. Run `make ami:${SLUG}/${CHANNEL}` to build an AMI from the Embedded Cluster
+   running your application in airgap mode.

--- a/secrets/REDACTED-params.yaml
+++ b/secrets/REDACTED-params.yaml
@@ -1,0 +1,30 @@
+application: slackernews-mackerel
+instance_type: m6i.xlarge
+volume_size: 50
+# us-west-2
+source_ami: ami-0c0f84ffda87399e6
+# us-east-1
+# source_ami: ami-0f890494e52693975
+replicated:
+    api_token: # REDACTED - a service account token for your Vendor Portal team
+aws:
+    access_key_id: # REDACTED - AWS access key id for the AWS account you'll publish the AMIs into
+    secret_access_key: # REDACTED - AWS access key id for the AWS account you'll publish the AMIs into 
+    regions: # update to control the regions you'll make the AMIS available in
+        - eu-central-1
+        - us-west-1
+        - ap-south-1
+        - eu-north-1
+        - ap-northeast-1
+        - ca-central-1
+        - eu-west-1
+        - sa-east-1
+        - us-east-1
+        - ap-southeast-1
+        - us-west-2
+        - eu-west-2
+        - ap-northeast-2
+        - us-east-2
+        - ap-southeast-2
+        - eu-west-3
+        - ap-northeast-3

--- a/secrets/params.yaml
+++ b/secrets/params.yaml
@@ -1,32 +1,55 @@
-application: slackernews
-admin_console_password: ENC[AES256_GCM,data:UnfOdxqWOyz0hTZouU6NXKqdLpcc/FFbfUiYtmoPuTlFqD1GCRf+aQ==,iv:9zG5lAi3Gvz76rz1WkjbFzwVfH7nOGdPUyox7wcKa3I=,tag:6xNw+VuqVPah0hXFK4PYug==,type:str]
+application: slackernews-mackerel
+admin_console_password: ENC[AES256_GCM,data:HWC5rc44f2FlAz0LRd8AgIPxixmzIDys06SaXFSzdoST/2vs4XL4tA==,iv:nHETvD7nIa7BDn3ABFBu8U4Pvp7RW7T10Mzzp4agG7I=,tag:v2a4QsdhQBVuN7Wge+cczQ==,type:str]
 instance_type: m6i.xlarge
 volume_size: 50
-source_ami: ami-0a8aed1ef66d8d061
+# us-west-2
+source_ami: ami-0c0f84ffda87399e6
+# us-east-1
+# source_ami: ami-0f890494e52693975
+replicated:
+    api_token: ENC[AES256_GCM,data:od3e5Plxay/r+cZwt3DeLxqH4D02HKB763mnqEqgN0RG80oE/ttY7lv6QuZxs4gUkf+OJnW9IH3g+WaUXpaJgA==,iv:jiUa88GVQJzljzkamF3UxDBBhhnqWzl/QSdhXkwhefw=,tag:Fy9znvc28VY6aCzfJoh7tA==,type:str]
+# replicated - for the development work
 aws:
-    access_key_id: ENC[AES256_GCM,data:de2r2d1dMN/3cZKKwOTgUCqAfNM=,iv:+PFlw3Bdxy5d0q5FWWZU6T3tkK5/LbodJF4ETjhPm+g=,tag:17OUdoQI5OFPBlyb36u01Q==,type:str]
-    secret_access_key: ENC[AES256_GCM,data:mXtRR6X0Q9h0v79MfvmyT8TVdi4CNAuAeb0aJ/3LWhGhzybjYVBinQ==,iv:gYqvmq29Xu6FtmASoZS6w+S7qnbQucg98hAx4rx7DaE=,tag:nBpWGQjbv++aaplQuPARtQ==,type:str]
-    region: us-west-2
+    access_key_id: ENC[AES256_GCM,data:jXhut2LzBsZZye28Q4EIGJSTFrY=,iv:I+DpRLccJNqWojeFqjjSkCA8y43E0EbkIoL6zt24eL4=,tag:ocx9KvrXk/tm0Gisk1BVgA==,type:str]
+    secret_access_key: ENC[AES256_GCM,data:+eSNfbaX1RIKLwhIgPrWTMjvWFfbWEAVOdZo7vK0UfhQa1N0M2GcgQ==,iv:M74vlIlWV3mhV1S+2H54jQXvNmjPrGAc8lQw+vpDaYY=,tag:pf9cEK5xdiLhrGjXUwy/5w==,type:str]
+    regions:
+        - eu-central-1
+        - us-west-1
+        - ap-south-1
+        - eu-north-1
+        - ap-northeast-1
+        - ca-central-1
+        - eu-west-1
+        - sa-east-1
+        - us-east-1
+        - ap-southeast-1
+        - us-west-2
+        - eu-west-2
+        - ap-northeast-2
+        - us-east-2
+        - ap-southeast-2
+        - eu-west-3
+        - ap-northeast-3
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-11-28T18:28:11Z"
-    mac: ENC[AES256_GCM,data:bGieVD1CR6N5vX6uQLTAR5EPZeW7Sjkvsq6OqB3+4HzBmI0nOfRvkKcjl+s7ZIK/ZNwnESQdAfXsCfjD/VjAH+UpuWvW93w5OJP6CrezIAWmO1s5INLF72Lg4tn9yARVz75kjnglk3GBNEF2MFcO/Z/c20JLuapmglGa6Sv1ZQ0=,iv:pHErOxyeeNb9lTop5yDpfC4jMNabV3LdVTqpJSw+QMM=,tag:SndWOJg88bKfQuHhnX4pcA==,type:str]
+    lastmodified: "2024-05-30T15:52:48Z"
+    mac: ENC[AES256_GCM,data:/Xvc+GzfAzB7sx7LsOvM6OpNZcOyEcd+HF/eXcUoVp1uXcZ/YikORh+IsKYEq1gZES7l14UE13GjhK1ALRiKBCMCAGWEwMCiSa4BsrfH3SzUFIROJAQGBAYI3yAS/Yd2ryKMOdnDySb8BwgKMM9XYk3l4Ypu7x0PaZksUb+SKtk=,iv:XUQ2/t6bpcAN6yQQXFodMvl+6VC6HhBru9bC9YYGIxg=,tag:4lscRy1Mh5S3JmwSot88nw==,type:str]
     pgp:
-        - created_at: "2023-11-28T15:58:14Z"
+        - created_at: "2023-12-07T20:18:33Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdA0E+JrbUKVtpW2zOQoYcuJWvxbhRUBkD+/DdAwnQp204w
-            vfVoSNlFUkxV2cinCajI3U7nAWLxLL/31/riExOCi0Kuux8WIpKtT025vE/reJSB
-            1GYBCQIQN5hHFfDz/CQnGl0K/Nsm5rA6JE9GYJ6ZGnkUz1US2AxhsH9tuDH4Z/vo
-            VpSgTwMze90qteu3CkVOcyoitkNytz/0FKMOViTUa04mBySR+E8aOOMisf9ptfYi
-            1joFsroK7Kc=
-            =IUeh
+            hF4DYhYgzaKQYR0SAQdA835NMsL4VZjKW3H+4z9CbXcMY48vWqe6bmn/2WeM5z0w
+            krkNWua6eLQcCz4CvTxhWKE2UoguvywW7ZZpUN7hvTX+Cu0BckjvXbRgA0lNCdFa
+            1GgBCQIQanIB0MPkGw/M1yvbgff0bc0Bs1/9mpFAl13/DMzYU4b7B/mixWjpiLE3
+            XE0pp4rVDIBIEUdy/i6e/QnwG+IjxPc/maDVug/QBqUNPpiqb9DOJ9qXRMunNHc0
+            wXLJMlssVth3Cg==
+            =/kuy
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D
-    encrypted_regex: access_key|password
+    encrypted_regex: access_key|password|api_token
     version: 3.8.1

--- a/src/packer/embedded-cluster.pkr.hcl
+++ b/src/packer/embedded-cluster.pkr.hcl
@@ -2,8 +2,11 @@ locals {
   user-data = templatefile("${var.project_root}/src/packer/templates/user-data.tmpl",
                              {
                                application = var.application
+                               channel = var.channel
                                install_dir = "/opt/${var.application}"
                                default_admin_console_password = var.admin_console_password
+                               replicated_api_token = var.replicated_api_token
+                               api_token = var.replicated_api_token
                              }
                           )
 }
@@ -18,7 +21,7 @@ packer {
 }
 
 source "amazon-ebs" "embedded-cluster" {
-  ami_name      = "${var.application}-ubuntu-22.04-lts"
+  ami_name      = "${var.application}-${var.channel}-ubuntu-22.04-lts"
   source_ami    = var.source_ami
   instance_type = var.instance_type
   
@@ -29,7 +32,13 @@ source "amazon-ebs" "embedded-cluster" {
 
   access_key = var.access_key_id
   secret_key = var.secret_access_key
-  region     = var.region
+  region     = var.build_region
+
+  ami_regions     = var.regions
+  ami_users       = [
+    "177217428600",
+    "429114214526"
+  ]
 
   ssh_username         = "ubuntu"
 
@@ -52,4 +61,9 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    inline = [
+      "rm /home/ubuntu/.ssh/authorized_keys"
+    ]
+  }
 }

--- a/src/packer/templates/user-data.tmpl
+++ b/src/packer/templates/user-data.tmpl
@@ -19,10 +19,14 @@ packages:
 - ca-certificates
 - curl
 - jq
+- python3-pip
 
 # Update apt database and upgrade packages on first boot
 package_update: true
 package_upgrade: true
+
+users:
+- default
 
 write_files:
 - path: /etc/ssh/sshd_config.d/01-hardening.conf
@@ -58,41 +62,53 @@ write_files:
   permissions: '0644'
   owner: root:root
 
-- path: /etc/systemd/system/${application}-install.service 
-  content: |
-    [Unit]
-    Description=The initial install for ${application}
-    After=sshd.service
-
-    [Service]
-    Type=oneshot
-    ExecStart=${install_dir}/${application} install --no-prompt
-    ExecStart=bash -c "echo ${default_admin_console_password} | $${HOME}/.config/.${application}/bin/kubectl kots reset-password --kubeconfig $${HOME}/.config/.${application}/etc/kubeconfig --namespace embedded-cluster"
-    RemainAfterExit=yes
-    # the embedded cluster binary writes certain files to the home directory, so let's
-    # us our install directory for that one
-    Environment=HOME=/root
-    Environment=PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-
-    [Install]
-    WantedBy=multi-user.target
-  permissions: '0755'
-  owner: root:root
-
 runcmd:
 - |
-  # download the latest release of the Replicated embedded cluster from GitHub
-  export INSTALL_DIR=${install_dir}
-  mkdir $${INSTALL_DIR}
-  wget -O $${INSTALL_DIR}/embedded-cluster.tar.gz -q "$(curl -s https://api.github.com/repos/replicatedhq/embedded-cluster/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("linux-amd64")).browser_download_url')"
-  tar xzf $${INSTALL_DIR}/embedded-cluster.tar.gz -C $${INSTALL_DIR} embedded-cluster && mv $${INSTALL_DIR}/embedded-cluster $${INSTALL_DIR}/${application} && rm $${INSTALL_DIR}/embedded-cluster.tar.gz
+  # install the Replicated CLI to use for the download step
+  curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+    | grep "browser_download_url.*linux_amd64.tar.gz" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | wget -O replicated.tar.gz -qi -
+  tar xf replicated.tar.gz replicated && rm replicated.tar.gz
+  mv replicated /usr/local/bin/replicated
+
+- | 
+  # Download the embedded cluster airgap tarball and unpack it for later install
+  export PATH=$${PATH}:/usr/local/bin
+  export REPLICATED_API_TOKEN=${api_token}
+  ids=$(replicated app ls --output json | jq -r --arg app ${application}  --arg channel ${channel} '.[] | select(.app.slug == $app ) | { "app_id": .app.id, "channel_id": .channels[] | select( .channelSlug == $channel ) | .id }')
+  app_id=$(echo $ids | jq -r '.app_id')
+  channel_id=$(echo $ids | jq -r '.channel_id')
+  echo "fetching airgap bundle from /v3/app/$${app_id}/channel/$${channel_id}/embeddedcluster/release\?airgap=true"
+  replicated api get \
+      /v3/app/$${app_id}/channel/$${channel_id}/embeddedcluster/release\?airgap=true \
+    > /home/ubuntu/slackernews-mackerel.tgz
+  tar -xzvf /home/ubuntu/slackernews-mackerel.tgz -C /home/ubuntu --owner ubuntu --group ubuntu
+  rm /home/ubuntu/slackernews-mackerel.tgz
+
+- |
+  # uninstall the Replicated CLI since it's not useful to a customer
+  rm /usr/local/bin/replicated
+
+- |
+  # install cloud formation bootstrap scripts and signal completion
+  curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -o /tmp/aws-cfn-bootstrap-latest.tar.gz \
+    && pip3 install /tmp/aws-cfn-bootstrap-latest.tar.gz \
+    && rm /tmp/aws-cfn-bootstrap-latest.tar.gz
+  
+- |
+  # install the boto3 library for accessing the AWS API
+  pip install boto3
 
 - |
   # download the Replicated KOTS CLI, which plugs into the `kubectl` command
   # and provides a subcommend to reset the password for the admin console
+  mkdir -p /var/lib/embedded-cluster/bin
+  export REPL_INSTALL_PATH=/var/lib/embedded-cluster/bin
   curl https://kots.io/install | bash
 
 - |
-  # enable the installation via systemd when an instance boots
-  systemctl daemon-reload
-  systemctl enable ${application}-install.service
+  # remove the authorized keys file for the user `root` to comply with Marketplace
+  # rules and avoid having a key on there that shouldn't be 
+  rm /root/.ssh/authorized_keys

--- a/src/packer/variables.pkr.hcl
+++ b/src/packer/variables.pkr.hcl
@@ -6,6 +6,10 @@ variable "application" {
   type = string
 }
 
+variable "channel" {
+  type = string
+}
+
 variable "admin_console_password" {
   type = string
 }
@@ -30,7 +34,15 @@ variable "secret_access_key" {
   type = string
 }
 
-variable "region" {
+variable "build_region" {
   type = string
+  default = "us-west-2"
 }
 
+variable "regions" {
+  type = list(string)
+}
+
+variable "replicated_api_token" {
+  type = string
+}


### PR DESCRIPTION
TL;DR
-----

Creates a AMI for an airgap embedded cluster for any app/channel combo
in your Vendor Portal team

Details
-------

Updates the creation process in two important ways:

1. Uses the airgap installer for the Embedded Cluster. This will
   facilitate AWS Marketplace approval of a product built around this
   AMI since no images need to be pulled from the Internet.
2. Updates the Makefile to have generalized targets that specify the
   applicatio and channel to use. These are generated dynamically with
   calls to the `replicated` CLI.

To build an image:

```
make ami:${SLUG}/${CHANNEL}
```
