### PR TITLE
Adapts the AMI for a app-specific default user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,121 @@
-# Replicated Embedded Cluster AMI
+# Replicated Embedded Cluster AMI Generator
 
-## TL;DR
+This project automates the creation of Amazon Machine Images (AMIs) for Replicated Embedded Cluster applications. It simplifies the process of packaging and distributing Replicated applications through AWS, enabling seamless deployment of air-gapped installations.
 
-1. Copy `secrets/REDACTED-params.yaml` to `secrets/params.yaml` and update for
-   your AWS account.
-2. Log in with the Replicated CLI 
-3. Run `make ami:${SLUG}/${CHANNEL}` to build an AMI from the Embedded Cluster
-   running your application in airgap mode.
+## Overview
+
+The AMI generator uses Packer to build customized AMIs that include:
+
+- A specific Replicated application and channel
+- The Embedded Cluster components
+- Cloud-init configuration for initial setup
+
+This allows customers to easily launch instances with your Replicated application pre-installed and ready to run in an air-gapped environment.
+
+## Usage
+
+### Prerequisites
+
+1. AWS account with appropriate permissions
+2. Replicated vendor account and API token
+3. Application configured in the Replicated vendor portal
+4. `make`, `packer`, `jq`, `sops`, `yq`, and AWS CLI tools installed locally
+
+### Preparing Parameters
+
+1. Copy `secrets/REDACTED-params.yaml` to `secrets/params.yaml`
+2. Update `params.yaml` with your AWS and Replicated credentials:
+
+```yaml
+aws:
+  access_key_id: YOUR_AWS_ACCESS_KEY
+  secret_access_key: YOUR_AWS_SECRET_KEY
+  regions: 
+    - us-east-1
+    - us-west-2
+
+replicated:
+  api_token: YOUR_REPLICATED_API_TOKEN
+
+instance_type: t3.large
+volume_size: 100
+source_ami: ami-12345678
+```
+
+3. Encrypt the params file:
+
+```
+make encrypt
+```
+
+### Generating an AMI
+
+The Makefile dynamically generates targets based on your Replicated Vendor Portal applications and channels. To build an AMI for a specific application and channel:
+
+```
+make ami:APP_SLUG/CHANNEL_SLUG
+```
+
+For example:
+
+```
+make ami:my-app/stable
+```
+
+To see all available targets:
+
+```
+make -qp | grep -E '^ami:'
+```
+
+This will list all the dynamically generated `ami:APP_SLUG/CHANNEL_SLUG` targets based on your current Replicated Vendor Portal configuration.
+
+## Components
+
+- **Makefile**: Orchestrates the entire process, dynamically generating targets based on your Replicated applications and channels
+- **Packer**: Defines the AMI configuration and build process
+- **Cloud-init**: Configures the instance on first boot, including Replicated application setup
+- **Replicated Vendor Portal**: Provides application metadata and release artifacts
+- **AWS**: Hosts the resulting AMI and allows for multi-region distribution
+
+## How It Works
+
+1. The Makefile queries the Replicated Vendor Portal to get all applications and channels
+2. It dynamically generates make targets for each application/channel combination
+3. When a target is invoked, it generates a Packer variables file with the necessary configuration
+4. Packer uses this configuration to launch an EC2 instance and customize it
+5. Cloud-init scripts run on first boot to set up the Replicated application
+6. Packer creates an AMI from the configured instance
+7. The AMI is shared to specified AWS regions and accounts
+
+## Key Makefile Features
+
+- **Dynamic Target Generation**: Automatically creates targets for all your Replicated applications and channels
+- **Parameter Management**: Handles the creation and encryption of parameter files
+- **Packer Integration**: Prepares variables for and executes Packer builds
+
+## Resulting AMI
+
+The generated AMI is specifically tailored for running your Replicated application in an air-gapped environment. Key features of the AMI include:
+
+- **Base OS**: Ubuntu 22.04 LTS
+- **Pre-installed Components**:
+  - Replicated Embedded Cluster
+  - Your specific application (based on the chosen channel)
+  - All necessary dependencies
+- **Configuration**:
+  - Cloud-init scripts for first-boot setup
+  - Customized user data for Replicated application initialization
+  - SSH hardening (custom sshd_config)
+- **Default User**: A user named after your application slug
+- **Volume**: Customized volume size (as specified in params.yaml)
+- **Security**:
+  - Root login disabled
+  - SSH password authentication disabled
+- **Multi-region**: The AMI is replicated to all specified AWS regions
+
+This AMI allows your customers to quickly deploy your application in an air-gapped environment with minimal additional configuration required. It's designed to be secure, efficient, and ready for production use.
+
+## Disclaimer
+
+This project is provided as an example and is not officially supported by Replicated. Use at your own risk and adapt as needed for your specific requirements.

--- a/secrets/params.yaml
+++ b/secrets/params.yaml
@@ -10,8 +10,9 @@ replicated:
     api_token: ENC[AES256_GCM,data:od3e5Plxay/r+cZwt3DeLxqH4D02HKB763mnqEqgN0RG80oE/ttY7lv6QuZxs4gUkf+OJnW9IH3g+WaUXpaJgA==,iv:jiUa88GVQJzljzkamF3UxDBBhhnqWzl/QSdhXkwhefw=,tag:Fy9znvc28VY6aCzfJoh7tA==,type:str]
 # replicated - for the development work
 aws:
-    access_key_id: ENC[AES256_GCM,data:jXhut2LzBsZZye28Q4EIGJSTFrY=,iv:I+DpRLccJNqWojeFqjjSkCA8y43E0EbkIoL6zt24eL4=,tag:ocx9KvrXk/tm0Gisk1BVgA==,type:str]
-    secret_access_key: ENC[AES256_GCM,data:+eSNfbaX1RIKLwhIgPrWTMjvWFfbWEAVOdZo7vK0UfhQa1N0M2GcgQ==,iv:M74vlIlWV3mhV1S+2H54jQXvNmjPrGAc8lQw+vpDaYY=,tag:pf9cEK5xdiLhrGjXUwy/5w==,type:str]
+    # Personal
+    access_key_id: ENC[AES256_GCM,data:b/PB0QTSfwV5jFjO5SkT/zSuR5w=,iv:cuhazc0ypsXB3kR4kIbWBr+TGa9MOF/0uNJYORRd+h4=,tag:pNbLI/yDs9tNm+LEdTpjiw==,type:str]
+    secret_access_key: ENC[AES256_GCM,data:HwZgDwWkZJDAetsvfE2pIX9KhIz1GQUCdFJcDwf42HY4iWKmeYqNuw==,iv:y1SxQb+PDTDfepv0p1unnUKRJg5Ubx4d+cBy134tePk=,tag:+u0NUD1aVGnhhh82tYs80Q==,type:str]
     regions:
         - eu-central-1
         - us-west-1
@@ -36,8 +37,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-05-30T15:52:48Z"
-    mac: ENC[AES256_GCM,data:/Xvc+GzfAzB7sx7LsOvM6OpNZcOyEcd+HF/eXcUoVp1uXcZ/YikORh+IsKYEq1gZES7l14UE13GjhK1ALRiKBCMCAGWEwMCiSa4BsrfH3SzUFIROJAQGBAYI3yAS/Yd2ryKMOdnDySb8BwgKMM9XYk3l4Ypu7x0PaZksUb+SKtk=,iv:XUQ2/t6bpcAN6yQQXFodMvl+6VC6HhBru9bC9YYGIxg=,tag:4lscRy1Mh5S3JmwSot88nw==,type:str]
+    lastmodified: "2024-06-05T16:40:24Z"
+    mac: ENC[AES256_GCM,data:UF8PXxmM1RrJjkO6GAEpXtVwqINkNoMtqEMOu1FhR2QMAvG7QuRcp5xI0BgURPfANUd89o+S6yjknjEJW05rfEEeS+moJPiQgVFWOJKG9TkVH09Uc5LaJAm4fcKw3bqx1wtEYcvvdInHJQoBi3hr+7TAd/THOWB85bPvBhcl6wo=,iv:W47uTEX4x44fAByfALSrBrrskN5kVSXvK2qo/hc1MYw=,tag:NBMBlWWqd7ngl+5QeyvuAw==,type:str]
     pgp:
         - created_at: "2023-12-07T20:18:33Z"
           enc: |-

--- a/src/packer/templates/user-data.tmpl
+++ b/src/packer/templates/user-data.tmpl
@@ -42,6 +42,8 @@ write_files:
     PasswordAuthentication yes
     ChallengeResponseAuthentication no
     PubkeyAuthentication yes
+    # disable root logins
+    PermitRootLogin no
   permissions: '0644'
   owner: root:root
  
@@ -77,15 +79,17 @@ runcmd:
   # Download the embedded cluster airgap tarball and unpack it for later install
   export PATH=$${PATH}:/usr/local/bin
   export REPLICATED_API_TOKEN=${api_token}
+  mkdir -p /opt/${application}
   ids=$(replicated app ls --output json | jq -r --arg app ${application}  --arg channel ${channel} '.[] | select(.app.slug == $app ) | { "app_id": .app.id, "channel_id": .channels[] | select( .channelSlug == $channel ) | .id }')
   app_id=$(echo $ids | jq -r '.app_id')
   channel_id=$(echo $ids | jq -r '.channel_id')
   echo "fetching airgap bundle from /v3/app/$${app_id}/channel/$${channel_id}/embeddedcluster/release\?airgap=true"
   replicated api get \
       /v3/app/$${app_id}/channel/$${channel_id}/embeddedcluster/release\?airgap=true \
-    > /home/ubuntu/slackernews-mackerel.tgz
-  tar -xzvf /home/ubuntu/slackernews-mackerel.tgz -C /home/ubuntu --owner ubuntu --group ubuntu
-  rm /home/ubuntu/slackernews-mackerel.tgz
+    > /opt/${application}/${application}.tgz
+  tar -xzvf /opt/${application}/${application}.tgz -C /opt/${application} --owner 1118 --group 1118
+  rm /opt/${application}/${application}.tgz
+  chown 1118:1118 -R /opt/${application}
 
 - |
   # uninstall the Replicated CLI since it's not useful to a customer
@@ -108,7 +112,20 @@ runcmd:
   export REPL_INSTALL_PATH=/var/lib/embedded-cluster/bin
   curl https://kots.io/install | bash
 
+- | 
+  # remove SSH host keys to ensure they are regenerated when an instance is launched
+  shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+
 - |
   # remove the authorized keys file for the user `root` to comply with Marketplace
   # rules and avoid having a key on there that shouldn't be 
   rm /root/.ssh/authorized_keys
+
+- |
+  # disable local root access
+  passwd -l root
+
+- |
+  # neuter the ubuntu user since the ${application} user is the new default
+  chsh -s /usr/sbin/nologin ubuntu
+

--- a/src/packer/variables.pkr.hcl
+++ b/src/packer/variables.pkr.hcl
@@ -10,10 +10,6 @@ variable "channel" {
   type = string
 }
 
-variable "admin_console_password" {
-  type = string
-}
-
 variable "instance_type" {
   type = string
 }


### PR DESCRIPTION
TL;DR
-----

Provides a default user named after the app slug

Details
-------

Shifts from the upstream `ubuntu` defualt user to a new defeault user
named after the application. This makese more sense in terms of branding
the experience and also allows for a potential shift in the underlying
distribution.
