### PR TITLE
Overwrites OVA when recreating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ work/$(1)-$(2)-ubuntu-22.04-lts/$(1)-$(2)-ubuntu-22.04-lts.ovf: $(PKRVARS_FILE) 
 
 work/$(1)-$(2)-ubuntu-22.04-lts.ova: work/$(1)-$(2)-ubuntu-22.04-lts/$(1)-$(2)-ubuntu-22.04-lts.ovf 
 	python src/python/add-ovf-properties.py --application $(1) --channel $(2) work/$(1)-$(2)-ubuntu-22.04-lts/$(1)-$(2)-ubuntu-22.04-lts.ovf 
-	ovftool --targetType=OVA --diskMode=thin work/$(1)-$(2)-ubuntu-22.04-lts/$(1)-$(2)-ubuntu-22.04-lts.ovf work/$(1)-$(2)-ubuntu-22.04-lts.ova
+	ovftool --targetType=OVA --diskMode=thin --overwrite work/$(1)-$(2)-ubuntu-22.04-lts/$(1)-$(2)-ubuntu-22.04-lts.ovf work/$(1)-$(2)-ubuntu-22.04-lts.ova
 
 validate\:$(1)/$(2): $(PKRVARS_FILE)
 	packer validate --var 'application=$(1)' --var 'channel=$(2)' \


### PR DESCRIPTION
TL;DR
-----

Avoids collision with existing OVA by overwriting it

Details
-------

Handles earlier annoyance where the OVA build would choke if the OVA
file already exists. Since we have decent rules in the `Makefile` we
want to overwrite it, so this change forces that.
