### PR TITLE
Repairs the Nix shell config on Apple Silicon

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  unstable =  import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") {};
+  unstable = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") {};
 in
 pkgs.mkShell {
   packages = [ 
@@ -11,11 +11,15 @@ pkgs.mkShell {
     unstable.packer
     pkgs.libisoburn
     pkgs.gomplate
-    unstable.ovftool
-    pkgs.python311  # Ensure a specific Python version
-    pkgs.python311Packages.lxml  # For XML handling
+    pkgs.python311
     pkgs.sops
     pkgs.awscli2
-  ];
+  ] ++ (if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64 then [] else [ unstable.ovftool ]);
+
+  shellHook = ''
+    if [[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]]; then
+      echo "⚠️ 🛠️You will need to manually install the OVF Tool on your Apple Silicon Mac";
+    fi
+  '';
 }
 


### PR DESCRIPTION
TL;DR
-----

Avoids trying to install `ovftool` with Nix on Apple Silicon

Details
-------

The current Nix package for `ovftool` is not available for Apple
Silicon. This change makes sure we don't try to install it and prints a
warning.
